### PR TITLE
Linter fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           PROPERTIES="$(./gradlew properties --console=plain -q)"
           VERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"
-          NAME="$(echo "$PROPERTIES" | grep "^name:" | cut -f2- -d ' ')"
+          NAME="$(echo "$PROPERTIES" | grep "^pluginName_:" | cut -f2- -d ' ')"
           CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
           CHANGELOG="${CHANGELOG//'%'/'%25'}"
           CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"

--- a/src/main/kotlin/com/github/khodand/pycharm/annotation/type/inspection/quickFixes/AssignmentAnnotationQuickFix.kt
+++ b/src/main/kotlin/com/github/khodand/pycharm/annotation/type/inspection/quickFixes/AssignmentAnnotationQuickFix.kt
@@ -6,9 +6,9 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiComment
 import com.intellij.util.IncorrectOperationException
+import com.jetbrains.python.psi.LanguageLevel
 import com.jetbrains.python.psi.PyAssignmentStatement
 import com.jetbrains.python.psi.PyElementGenerator
-import com.jetbrains.python.psi.LanguageLevel
 
 /**
  * This class provides a solution to inspection not annotated variables by manipulating

--- a/src/main/kotlin/com/github/khodand/pycharm/annotation/type/inspection/quickFixes/FunctionAnnotationQuickFix.kt
+++ b/src/main/kotlin/com/github/khodand/pycharm/annotation/type/inspection/quickFixes/FunctionAnnotationQuickFix.kt
@@ -58,7 +58,7 @@ class FunctionAnnotationQuickFix : LocalQuickFix {
             annotatedFunction.parameterList.replace(function.parameterList)
             annotatedFunction.statementList.replace(function.statementList)
             if (function.lastChild.prevSibling.prevSibling is PsiComment) {
-                 annotatedFunction.lastChild.prevSibling.prevSibling.replace(function.lastChild.prevSibling.prevSibling)
+                annotatedFunction.lastChild.prevSibling.prevSibling.replace(function.lastChild.prevSibling.prevSibling)
             } else {
                 annotatedFunction.lastChild.prevSibling.prevSibling.delete()
             }

--- a/src/test/kotlin/com/github/khodand/pycharm/annotation/type/inspection/TypeAnnotationsInspectionTest.kt
+++ b/src/test/kotlin/com/github/khodand/pycharm/annotation/type/inspection/TypeAnnotationsInspectionTest.kt
@@ -5,7 +5,6 @@ import com.github.khodand.pycharm.annotation.type.inspection.quickFixes.Function
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase
 import org.junit.Test
 
-
 internal class TypeAnnotationsInspectionTest : LightPlatformCodeInsightFixture4TestCase() {
     override fun getTestDataPath(): String? {
         return "src/test/testData"


### PR DESCRIPTION
Reorder imports in AssignmentAnnotation and deletes extra space